### PR TITLE
Handle PTR queries

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -121,10 +121,15 @@ func (s *DNSServer) listDomains(service *Service) chan string {
 	c := make(chan string)
 
 	go func() {
-		domain := service.Image + "." + s.config.domain.String() + "."
 
-		c <- domain
-		c <- service.Name + "." + domain
+		if service.Image == "" {
+			c <- service.Name + "." + s.config.domain.String() + "."
+		} else {
+			domain := service.Image + "." + s.config.domain.String() + "."
+
+			c <- domain
+			c <- service.Name + "." + domain
+		}
 
 		close(c)
 	}()

--- a/dnsserver_test.go
+++ b/dnsserver_test.go
@@ -40,13 +40,14 @@ func TestDNSResponse(t *testing.T) {
 
 	server.AddService("foo", Service{Name: "foo", Image: "bar", Ip: net.ParseIP("127.0.0.1")})
 	server.AddService("baz", Service{Name: "baz", Image: "bar", Ip: net.ParseIP("127.0.0.1"), Ttl: -1})
+	server.AddService("biz", Service{Name: "hey", Image: "", Ip: net.ParseIP("127.0.0.4")})
 
 	var inputs = []struct {
 		query    string
 		expected int
 	}{
-		{"docker.", 2},
-		{"*.docker.", 2},
+		{"docker.", 3},
+		{"*.docker.", 3},
 		{"bar.docker.", 2},
 		{"foo.docker.", 0},
 		{"baz.bar.docker.", 1},
@@ -82,8 +83,9 @@ func TestDNSResponse(t *testing.T) {
 		query    string
 		expected int
 	}{
-		{"1.0.0.127.in-addr.arpa.", 4},
-		{"2.0.0.127.in-addr.arpa.", 0},
+		{"1.0.0.127.in-addr.arpa.", 4}, // two services match with two domains each
+		{"4.0.0.127.in-addr.arpa.", 1}, // only one service with a single domain
+		{"2.0.0.127.in-addr.arpa.", 0}, // no match
 	}
 
 	for _, input := range ptrInputs {

--- a/dnsserver_test.go
+++ b/dnsserver_test.go
@@ -82,7 +82,7 @@ func TestDNSResponse(t *testing.T) {
 		query    string
 		expected int
 	}{
-		{"1.0.0.127.in-addr.arpa.", 2},
+		{"1.0.0.127.in-addr.arpa.", 4},
 		{"2.0.0.127.in-addr.arpa.", 0},
 	}
 


### PR DESCRIPTION
This PR adds a basic support for PTR queries.

Sample *dig* output:
```console
$ dig @127.0.0.1 -p 4242 -x 172.17.0.57

; <<>> DiG 9.9.5-9-Debian <<>> @127.0.0.1 -p 4242 -x 172.17.0.57
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 61158
;; flags: qr rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;57.0.17.172.in-addr.arpa.	IN	PTR

;; ANSWER SECTION:
57.0.17.172.in-addr.arpa. 20	IN	PTR	backend.docker.
57.0.17.172.in-addr.arpa. 20	IN	PTR	backend_web_1.backend.docker.

;; Query time: 0 msec
;; SERVER: 127.0.0.1#4242(127.0.0.1)
;; WHEN: Thu May 28 17:18:02 CEST 2015
;; MSG SIZE  rcvd: 160
```