### PR TITLE
Support aliases

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -132,6 +132,10 @@ func (s *DNSServer) listDomains(service *Service) chan string {
 			c <- service.Name + "." + domain
 		}
 
+		for _, alias := range service.Aliases {
+			c <- alias + "."
+		}
+
 		close(c)
 	}()
 

--- a/dnsserver.go
+++ b/dnsserver.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Service struct {
-	Name  string
-	Image string
-	Ip    net.IP
-	Ttl   int
+	Name    string
+	Image   string
+	Ip      net.IP
+	Ttl     int
+	Aliases []string
 }
 
 func NewService() (s *Service) {
@@ -280,6 +281,13 @@ func (s *DNSServer) queryServices(query string) chan *Service {
 
 			if isPrefixQuery(query, test) {
 				c <- service
+			}
+
+			// check aliases
+			for _, alias := range service.Aliases {
+				if isPrefixQuery(query, strings.Split(alias, ".")) {
+					c <- service
+				}
 			}
 		}
 

--- a/dnsserver_test.go
+++ b/dnsserver_test.go
@@ -41,16 +41,18 @@ func TestDNSResponse(t *testing.T) {
 	server.AddService("foo", Service{Name: "foo", Image: "bar", Ip: net.ParseIP("127.0.0.1")})
 	server.AddService("baz", Service{Name: "baz", Image: "bar", Ip: net.ParseIP("127.0.0.1"), Ttl: -1})
 	server.AddService("biz", Service{Name: "hey", Image: "", Ip: net.ParseIP("127.0.0.4")})
+	server.AddService("joe", Service{Name: "joe", Image: "", Ip: net.ParseIP("127.0.0.5"), Aliases: []string{"lala.docker"}})
 
 	var inputs = []struct {
 		query    string
 		expected int
 	}{
-		{"docker.", 3},
-		{"*.docker.", 3},
+		{"docker.", 5},
+		{"*.docker.", 5},
 		{"bar.docker.", 2},
 		{"foo.docker.", 0},
 		{"baz.bar.docker.", 1},
+		{"joe.docker.", 1},
 	}
 
 	for _, input := range inputs {

--- a/docker.go
+++ b/docker.go
@@ -63,6 +63,7 @@ func (d *DockerManager) getService(id string) (*Service, error) {
 	}
 
 	service := NewService()
+	service.Aliases = make([]string, 0)
 
 	service.Image = getImageName(inspect.Config.Image)
 	if imageNameIsSHA(service.Image, inspect.Image) {
@@ -143,6 +144,10 @@ func overrideFromEnv(in *Service, env map[string]string) (out *Service) {
 	for k, v := range env {
 		if k == "DNSDOCK_IGNORE" || k == "SERVICE_IGNORE" {
 			return nil
+		}
+
+		if k == "DNSDOCK_ALIAS" {
+			in.Aliases = strings.Split(v, ",")
 		}
 
 		if k == "DNSDOCK_NAME" {

--- a/http.go
+++ b/http.go
@@ -154,6 +154,12 @@ func (s *HTTPServer) updateService(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	if image, ok := input["alias"]; ok {
+		if value, ok := image.([]string); ok {
+			service.Aliases = value
+		}
+	}
+
 	// todo: this probably needs to be moved. consider stop event in the
 	// middle of sending PATCH. container would not be removed.
 	s.list.AddService(id, service)

--- a/http_test.go
+++ b/http_test.go
@@ -27,14 +27,14 @@ func TestServiceRequests(t *testing.T) {
 		{"GET", "/services", "", "{}", 200},
 		{"GET", "/services/foo", "", "", 404},
 		{"PUT", "/services/foo", `{"name": "foo"}`, "", 500},
-		{"PUT", "/services/foo", `{"name": "foo", "image": "bar", "ip": "127.0.0.1"}`, "", 200},
-		{"GET", "/services/foo", "", `{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1}`, 200},
+		{"PUT", "/services/foo", `{"name": "foo", "image": "bar", "ip": "127.0.0.1", "aliases": ["foo.docker"]}`, "", 200},
+		{"GET", "/services/foo", "", `{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1,"Aliases":["foo.docker"]}`, 200},
 		{"PUT", "/services/boo", `{"name": "baz", "image": "bar", "ip": "127.0.0.2"}`, "", 200},
-		{"GET", "/services", "", `{"boo":{"Name":"baz","Image":"bar","Ip":"127.0.0.2","Ttl":-1},"foo":{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1}}`, 200},
+		{"GET", "/services", "", `{"boo":{"Name":"baz","Image":"bar","Ip":"127.0.0.2","Ttl":-1,"Aliases":null},"foo":{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1,"Aliases":["foo.docker"]}}`, 200},
 		{"PATCH", "/services/boo", `{"name": "bar", "ttl": 20, "image": "bar"}`, "", 200},
-		{"GET", "/services/boo", "", `{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20}`, 200},
+		{"GET", "/services/boo", "", `{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20,"Aliases":null}`, 200},
 		{"DELETE", "/services/foo", ``, "", 200},
-		{"GET", "/services", "", `{"boo":{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20}}`, 200},
+		{"GET", "/services", "", `{"boo":{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20,"Aliases":null}}`, 200},
 	}
 
 	for _, input := range tests {

--- a/readme.md
+++ b/readme.md
@@ -123,12 +123,18 @@ curl http://dnsdock.docker/set/ttl -X PUT --data-ascii '10'
 
 If you wish to fine tune the DNS response addresses you can define specific environment variables during container startup. This overrides the default matching scheme from container and image name.
 
-Supported ENV variables are `DNSDOCK_NAME`, `DNSDOCK_IMAGE`, `DNSDOCK_TTL`.
+Supported ENV variables are `DNSDOCK_NAME`, `DNSDOCK_IMAGE`, `DNSDOCK_ALIAS`, `DNSDOCK_TTL`.
 
 ```
 docker run -e DNSDOCK_NAME=master -e DNSDOCK_IMAGE=mysql -e DNSDOCK_TTL=10 \
            --name mymysql mysqlimage
 # matches master.mysql.docker
+```
+
+```
+docker run -e DNSDOCK_ALIAS=db.docker,sql.docker -e DNSDOCK_TTL=10 \
+           --name mymysql mysqlimage
+# matches db.docker and sql.docker
 ```
 
 Service metadata syntax by [progrium/registrator](https://github.com/progrium/registrator) is also supported.


### PR DESCRIPTION
This PR adds support for multiple aliases (A records, only if the alias uses the same domain as the configuration).

Aliases can be defined using an environment variable (`DNSDOCK_ALIAS`) or with the HTTP API. In both case, multiple aliases are coma-separated.