### PR TITLE
prefix long options with double dashes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ redis1.*.docker.		0	IN	A	172.17.42.2
 
 #### Setup
 
-DNS listening port needs to be binded to the *docker0* inferface so that its available to all containers. To avoid this IP changing during host restart add it the docker default options. Open file `/etc/default/docker` and add `-bip=172.17.42.1/24 -dns 172.17.42.1` to `DOCKER_OPTS` variable. Restart docker daemon after you have done that (`sudo service docker restart`).
+DNS listening port needs to be binded to the *docker0* inferface so that its available to all containers. To avoid this IP changing during host restart add it the docker default options. Open file `/etc/default/docker` and add `--bip=172.17.42.1/24 --dns 172.17.42.1` to `DOCKER_OPTS` variable. Restart docker daemon after you have done that (`sudo service docker restart`).
 
 Now you only need to run the dnsdock container:
 


### PR DESCRIPTION
I thinks this is was a mistake, because the sample in the default file reads : 

`#DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"`

(double dashes too)