### PR TITLE
Respond with SOA in the authority section when no records found.

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -355,10 +355,10 @@ func (s *DNSServer) createSOA() []dns.RR {
 	dom := dns.Fqdn(s.config.domain.String() + ".")
 	soa := &dns.SOA{
 		Hdr: dns.RR_Header{
-			Name: dom,
+			Name:   dom,
 			Rrtype: dns.TypeSOA,
-			Class: dns.ClassINET,
-			Ttl: uint32(s.config.ttl)},
+			Class:  dns.ClassINET,
+			Ttl:    uint32(s.config.ttl)},
 		Ns:      "dnsdock." + dom,
 		Mbox:    "dnsdock.dnsdock." + dom,
 		Serial:  uint32(time.Now().Truncate(time.Hour).Unix()),

--- a/dnsserver_test.go
+++ b/dnsserver_test.go
@@ -72,13 +72,11 @@ func TestDNSResponse(t *testing.T) {
 			break
 		}
 		if len(in.Answer) == 0 {
-			t.Error(input, "No SOA anwer")
-		}
-		if _, ok := in.Answer[0].(*dns.SOA); ok {
-			if input.expected != 0 {
-				t.Error(input, "Expected:", input.expected, " Got:", 0)
+			if _, ok := in.Ns[0].(*dns.SOA); !ok {
+				t.Error(input, "No SOA anwer")
 			}
-		} else if len(in.Answer) != input.expected {
+		}
+		if len(in.Answer) != input.expected {
 			t.Error(input, "Expected:", input.expected, " Got:", len(in.Answer))
 		}
 	}
@@ -108,13 +106,11 @@ func TestDNSResponse(t *testing.T) {
 			break
 		}
 		if len(in.Answer) == 0 {
-			t.Error(input, "No SOA anwer")
-		}
-		if _, ok := in.Answer[0].(*dns.SOA); ok {
-			if input.expected != 0 {
-				t.Error(input, "Expected:", input.expected, " Got:", 0)
+			if _, ok := in.Ns[0].(*dns.SOA); !ok {
+				t.Error(input, "No SOA anwer")
 			}
-		} else if len(in.Answer) != input.expected {
+		}
+		if len(in.Answer) != input.expected {
 			t.Error(input, "Expected:", input.expected, " Got:", len(in.Answer))
 		}
 	}


### PR DESCRIPTION
When no records were found for a particular request, instead of sending one Answer with the SOA record, we should instead set the Rcode to NXDOMAIN and provide the SOA record in the Ns (authority) section of the reply. Also, we can claim to have SOA over the domain provided on launch, and generate a reasonable hostname for ourselves (dnsdock.domain). 