### PR TITLE
Enable mutual TLS authentication with Docker daemon

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,10 @@ type Config struct {
 	dnsAddr    string
 	domain     Domain
 	dockerHost string
+	tlsVerify  bool
+	tlsCaCert  string
+	tlsCert    string
+	tlsKey     string
 	verbose    bool
 	httpAddr   string
 	ttl        int
@@ -37,6 +41,11 @@ func NewConfig() *Config {
 	if len(dockerHost) == 0 {
 		dockerHost = "unix:///var/run/docker.sock"
 	}
+	tlsVerify := len(os.Getenv("DOCKER_TLS_VERIFY")) != 0
+	dockerCerts := os.Getenv("DOCKER_CERT_PATH")
+	if len(dockerCerts) == 0 {
+		dockerCerts = os.Getenv("HOME") + "/.docker"
+	}
 
 	return &Config{
 		nameserver: "8.8.8.8:53",
@@ -44,6 +53,10 @@ func NewConfig() *Config {
 		domain:     NewDomain("docker"),
 		dockerHost: dockerHost,
 		httpAddr:   ":80",
+		tlsVerify:  tlsVerify,
+		tlsCaCert:  dockerCerts + "/ca.pem",
+		tlsCert:    dockerCerts + "/cert.pem",
+		tlsKey:     dockerCerts + "/key.pem",
 	}
 
 }

--- a/docker.go
+++ b/docker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"log"
 	"net"
@@ -17,8 +18,8 @@ type DockerManager struct {
 	docker *dockerclient.DockerClient
 }
 
-func NewDockerManager(c *Config, list ServiceListProvider) (*DockerManager, error) {
-	docker, err := dockerclient.NewDockerClient(c.dockerHost, nil)
+func NewDockerManager(c *Config, list ServiceListProvider, tlsConfig *tls.Config) (*DockerManager, error) {
+	docker, err := dockerclient.NewDockerClient(c.dockerHost, tlsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 )
@@ -20,6 +23,10 @@ func main() {
 	domain := flag.String("domain", config.domain.String(), "Domain that is appended to all requests")
 	environment := flag.String("environment", "", "Optional context before domain suffix")
 	flag.StringVar(&config.dockerHost, "docker", config.dockerHost, "Path to the docker socket")
+	flag.BoolVar(&config.tlsVerify, "tlsverify", true, "Enable mTLS when connecting to docker")
+	flag.StringVar(&config.tlsCaCert, "tlscacert", config.tlsCaCert, "Path to CA certificate")
+	flag.StringVar(&config.tlsCert, "tlscert", config.tlsCert, "Path to client certificate")
+	flag.StringVar(&config.tlsKey, "tlskey", config.tlsKey, "Path to client certificate private key")
 	flag.BoolVar(&config.verbose, "verbose", true, "Verbose output")
 	flag.IntVar(&config.ttl, "ttl", config.ttl, "TTL for matched requests")
 
@@ -45,7 +52,26 @@ func main() {
 
 	dnsServer := NewDNSServer(config)
 
-	docker, err := NewDockerManager(config, dnsServer)
+	var tlsConfig *tls.Config = nil
+	if config.tlsVerify {
+		clientCert, err := tls.LoadX509KeyPair(config.tlsCert, config.tlsKey)
+		if err != nil {
+			log.Fatal(err)
+		}
+		tlsConfig := &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{clientCert},
+		}
+		pemData, err := ioutil.ReadFile(config.tlsCaCert)
+		if err == nil {
+			rootCert := x509.NewCertPool()
+			rootCert.AppendCertsFromPEM(pemData)
+			tlsConfig.RootCAs = rootCert
+		} else {
+			log.Print(err)
+		}
+	}
+	docker, err := NewDockerManager(config, dnsServer, tlsConfig)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		tlsConfig := &tls.Config{
+		tlsConfig = &tls.Config{
 			MinVersion:   tls.VersionTLS12,
 			Certificates: []tls.Certificate{clientCert},
 		}

--- a/readme.md
+++ b/readme.md
@@ -107,15 +107,13 @@ You may build this into your own container with this example Dockerfile:
 ```
 FROM tonistiigi/dnsdock
 
-COPY certs/ca.pem /certs/
-COPY certs/cert.pem /certs/
-COPY certs/key.pem /certs/
-
 ENV DOCKER_TLS_VERIFY 1
 ENV DOCKER_CERTS /certs
 
 CMD ["-docker=tcp://172.17.42.1:2376"]
 ```
+
+Use a volume (`-v /path/to/certs:/certs`) to give the container access to the certificate files, or build the certificates into the image if you have access to a secure private image registry.
 
 #### HTTP Server
 

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,10 @@ Additional configuration options to dnsdock command:
 -nameserver="8.8.8.8:53": DNS server for unmatched requests
 -ttl=0: TTL for matched requests
 -verbose=true: Verbose output
+-tlsverify=false: enable mutual TLS between dnsdock and Docker
+-tlscacert="$HOME/.docker/ca.pem": Path to CA certificate
+-tlscert="$HOME/.docker/cert.pem": Path to client certificate
+-tlskey="$HOME/.docker/key.pem": Path to client certificate private key
 ```
 
 If you also want to let the host machine discover the containers add `nameserver 172.17.42.1` to your `/etc/resolv.conf`.
@@ -93,6 +97,25 @@ If you also want to let the host machine discover the containers add `nameserver
 #### SELinux and Fedora / RHEL / CentOS
 
 Mounting docker daemon's unix socket may not work with default configuration on these platforms. Please use [selinux-dockersock](https://github.com/dpw/selinux-dockersock) to fix this. More information in [#11](https://github.com/tonistiigi/dnsdock/issues/11).
+
+#### TLS Authentication
+
+Instead of connecting to the Docker daemon's UNIX socket, you may prefer to connect via a TLS-protected TCP socket (for example, if you are running Swarm). The `-tlsverify` option enables TLS, and the three additional options (`-tlscacert`, `-tlscert` and `-tlskey`) must also be specified. Alternatively, you may set the `DOCKER_TLS_VERIFY` environment variable to a non-empty value and the `DOCKER_CERTS` to a directory containing files named `ca.pem`, `cert.pem` and `key.pem`.
+
+You may build this into your own container with this example Dockerfile:
+
+```
+FROM tonistiigi/dnsdock
+
+COPY certs/ca.pem /certs/
+COPY certs/cert.pem /certs/
+COPY certs/key.pem /certs/
+
+ENV DOCKER_TLS_VERIFY 1
+ENV DOCKER_CERTS /certs
+
+CMD ["-docker=tcp://172.17.42.1:2376"]
+```
 
 #### HTTP Server
 


### PR DESCRIPTION
Particularly when running on Docker Swarm, but potentially in any situation, users may want to connect to the Docker daemon via TLS. This PR adds the necessary command line flags, environment variable parsing and TLS configuration to enable mutual TLS authentication.