### PR TITLE
RFC 4074 compliance

### DIFF
--- a/dnsserver_test.go
+++ b/dnsserver_test.go
@@ -34,6 +34,7 @@ func TestDNSResponse(t *testing.T) {
 	}{
 		{"google.com.", -1, "A", dns.RcodeSuccess},
 		{"google.com.", -1, "MX", 0},
+		{"google.com.", -1, "AAAA", 0}, // google has AAAA records
 		{"docker.", 5, "A", 0},
 		{"docker.", 5, "MX", 0},
 		{"*.docker.", 5, "A", 0},
@@ -81,6 +82,10 @@ func TestDNSResponse(t *testing.T) {
 		if input.expected > 0 && len(r.Answer) != input.expected {
 			t.Error(input, "Expected:", input.expected,
 				" Got:", len(r.Answer))
+		}
+
+		if input.expected < 0 && len(r.Answer) == 0 {
+			t.Error(input, "Expected at least one record but got none")
 		}
 
 		if r.Rcode != input.rcode {


### PR DESCRIPTION
Addresses #4. From the [RFC](https://www.ietf.org/rfc/rfc4074.txt):

> 3.  Expected Behavior
>
>   Suppose that an authoritative server has an A RR but has no AAAA RR for a host name.  Then, the server should return a response to a query for an AAAA RR of the name with the response code (RCODE) being 0 (indicating no error) and with an empty answer section (see Sections 4.3.2 and 6.2.4 of [1]).  Such a response indicates that there is at least one RR of a different type than AAAA for the queried name, and the stub resolver can then look for A RRs.

This patch:
* Correctly returns NOERROR but no records when confronted with an AAAA query for a name that it knows about. 
* Correctly returns NXDOMAIN and no records when confronted with any query for a name under the base domain that doesn't match a registered service.
* Requests for names not under the base domain and not exact alias matches will be forwarded if the downstream name server returns a reply; this should allow proper AAAA replies to be returned from downstream if they are available.
    * If the downstream name server does not reply, REFUSED will be returned for invalid queries. This matches the behavior I can see from other non-forwarding name servers.
* Has updated tests to capture expected behavior for both supported and non-supported record types, as well as expected response codes.
* Probably provides better forwarding performance due to more efficient mux patterns.
