### PR TITLE
Query by hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.4.1
 
-ADD . /go/src/github.com/tonistiigi/dnsdock
+RUN go get -v github.com/tools/godep
 
-RUN cd /go/src/github.com/tonistiigi/dnsdock && \
-    go get -v github.com/tools/godep && \
-    godep restore && \
-    go install -ldflags "-X main.version `git describe --tags HEAD``if [[ -n $(command git status --porcelain --untracked-files=no 2>/dev/null) ]]; then echo "-dirty"; fi`" ./...
+ADD ./Godeps /go/src/github.com/tonistiigi/dnsdock/Godeps
+WORKDIR /go/src/github.com/tonistiigi/dnsdock/
+RUN godep restore
 
-ENTRYPOINT ["/go/bin/dnsdock"] 
+ADD . /go/src/github.com/tonistiigi/dnsdock/
+RUN go install -ldflags "-X main.version `git describe --tags HEAD``if [[ -n $(command git status --porcelain --untracked-files=no 2>/dev/null) ]]; then echo "-dirty"; fi`" ./...
+
+ENTRYPOINT ["/go/bin/dnsdock"]

--- a/dnsserver.go
+++ b/dnsserver.go
@@ -15,6 +15,7 @@ import (
 type Service struct {
 	Name    string
 	Image   string
+	Hostname string
 	Ip      net.IP
 	Ttl     int
 	Aliases []string
@@ -366,7 +367,10 @@ func (s *DNSServer) queryServices(query string) chan *Service {
 
 			test = append(test, s.config.domain...)
 
-			if isPrefixQuery(query, test) {
+			// check if the query matches the virtual hostname or the explicitly
+			// defined hostname of this service
+			if isPrefixQuery(query, test) ||
+			   isPrefixQuery(query, strings.Split(service.Hostname, ".")) {
 				c <- service
 			}
 

--- a/docker.go
+++ b/docker.go
@@ -72,6 +72,7 @@ func (d *DockerManager) getService(id string) (*Service, error) {
 		service.Image = ""
 	}
 	service.Name = cleanContainerName(inspect.Name)
+	service.Hostname = inspect.Config.Hostname + "." + inspect.Config.Domainname
 	service.Ip = net.ParseIP(inspect.NetworkSettings.IPAddress)
 
 	service = overrideFromEnv(service, splitEnv(inspect.Config.Env))


### PR DESCRIPTION
This is a simple, but very convenient feature borrowed from [WeaveDNS](http://docs.weave.works/weave/latest_release/weavedns.html).

Docker already has built-in support for [specifying a container's hostname](https://docs.docker.com/reference/run/#env-environment-variables) via the `-h` option. Compose [supports a corresponding `hostname` property](https://docs.docker.com/compose/yml/#working-dir-entrypoint-user-hostname-domainname-mac-address-mem-limit-memswap-limit-privileged-restart-stdin-open-tty-cpu-shares-cpuset-read-only-volume-driver).

These options will set the HOSTNAME environment variable, which in turn will notify the container about what its own hostname is.

By enabling dnsdock to automatically register DNS entries matching the hostname setting, the DNS server and the container itself can be configured simultaneously.

``` sh
$ docker run -e DNSDOCK_ALIAS=myservice.docker -h myservice.docker --rm ubuntu hostname
myservice.docker
```

becomes

``` sh
$ docker run -h myservice.docker --rm ubuntu hostname
myservice.docker
```