### PR TITLE
Enable 'recursion available' bit

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -215,6 +215,7 @@ func (s *DNSServer) makeServiceMX(n string, service *Service) dns.RR {
 func (s *DNSServer) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 	m := new(dns.Msg)
 	m.SetReply(r)
+	m.RecursionAvailable = true
 
 	// Send empty response for empty requests
 	if len(r.Question) == 0 {
@@ -269,6 +270,7 @@ func (s *DNSServer) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 func (s *DNSServer) handleReverseRequest(w dns.ResponseWriter, r *dns.Msg) {
 	m := new(dns.Msg)
 	m.SetReply(r)
+	m.RecursionAvailable = true
 
 	// Send empty response for empty requests
 	if len(r.Question) == 0 {


### PR DESCRIPTION
Resolves #34 by enabling the RA (recursion available) bit on all replies.

You may think that this should only be set if the user has specified a forwarding name server, but since this resolves an issue entire unrelated to forwarding, and there doesn't seem to be any reason to avoid returning this bit, this is the most reliable solution to the problem.