### PR TITLE
Fix build warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN cd /go/src/github.com/tonistiigi/dnsdock && \
     godep restore && \
     go install -ldflags "-X main.version `git describe --tags HEAD``git status --porcelain --untracked-files=no 2>/dev/null | grep -q ^ && echo "-dirty"`" ./...
 
-ENTRYPOINT ["/go/bin/dnsdock"] 
+ENTRYPOINT ["/go/bin/dnsdock"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ADD . /go/src/github.com/tonistiigi/dnsdock
 RUN cd /go/src/github.com/tonistiigi/dnsdock && \
     go get -v github.com/tools/godep && \
     godep restore && \
-    go install -ldflags "-X main.version `git describe --tags HEAD``if [[ -n $(command git status --porcelain --untracked-files=no 2>/dev/null) ]]; then echo "-dirty"; fi`" ./...
+    go install -ldflags "-X main.version `git describe --tags HEAD``git status --porcelain --untracked-files=no 2>/dev/null | grep -q ^ && echo "-dirty"`" ./...
 
 ENTRYPOINT ["/go/bin/dnsdock"] 


### PR DESCRIPTION
See #42. The backtick commands don't seem to be running in a bash shell, so the `[[` syntax isn't available. I rewrote it slightly to be more generally portable.