### PR TITLE
Set aa bit when returning response for AAAA queries.

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -250,6 +250,7 @@ func (s *DNSServer) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 			// a record with this name. Per RFC 4074 sec. 3, we
 			// immediately return an empty NOERROR reply.
 			m.Ns = s.createSOA()
+			m.MsgHdr.Authoritative = true
 			w.WriteMsg(m)
 			return
 		}


### PR DESCRIPTION
I was getting EAI_FAIL on ubuntu getaddrinfo() calls when trying to resolve dns names for other docker containers.  Reading rfc4074 section 4.5 makes me think this bit should be set, and setting it seems to fix my problem. I think this might be what others are seeing for #34, as I see the same symptoms.