### PR TITLE
Support for Containers w/ Uppercase Characters

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -357,7 +357,7 @@ func (s *DNSServer) queryServices(query string) chan *Service {
 			test := []string{}
 			// todo: add some cache to avoid calculating this every time
 			if len(service.Name) > 0 {
-				test = append(test, strings.Split(service.Name, ".")...)
+				test = append(test, strings.Split(strings.ToLower(service.Name), ".")...)
 			}
 
 			if len(service.Image) > 0 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 # /var/run/docker.sock does not seem to be available for fig
 # for this reason we violate LFHS and add the socket directly on /run
 dnsdock:
-    image: tonistiigi/dnsdock
+    image: conz27/dnsdock
+    container_name: dnsdock
     volumes:
         - /var/run/docker.sock:/run/docker.sock
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@
 dnsdock:
     image: conz27/dnsdock
     container_name: dnsdock
+    command: -nameserver 192.168.0.1:53 -nameserver 8.8.8.8:53
     volumes:
         - /var/run/docker.sock:/run/docker.sock
     ports:
-        - 172.17.42.1:53:53/udp
+        - 172.17.0.0:53:53/udp


### PR DESCRIPTION
PROBLEM SUMMARY:

If a container named "bigTEST" was created while dnsdock was running,
using "dig @172.17.42.1 bigTEST.test_image.docker" would NOT resolve.
However, if the container was named "bigtest", it would work just fine.
Handling uppercase letters in the service name was the crux of the
problem.

SOLUTION:

Because users in Docker are free to use uppercase letters for naming the
service, DNS should resolve the container name correctly because DNS is
case-insenstive. Hence "bigTEST.test_image.docker" should be equivalent
to "bigtest.test_image.docker".

A problem not solved here is if a user starts "bigTEST" and "bigtest".
Then you end up with multiple DNS A records ... which may not be correct
behaviour.