### PR TITLE
Return service before domain during reverse resolution

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -137,8 +137,8 @@ func (s *DNSServer) listDomains(service *Service) chan string {
 		} else {
 			domain := service.Image + "." + s.config.domain.String() + "."
 
-			c <- domain
 			c <- service.Name + "." + domain
+			c <- domain
 		}
 
 		for _, alias := range service.Aliases {


### PR DESCRIPTION
dnsdock should return a more specific name when available, as anyone reverse
resolving an address is more interested in a name which resolves directly to
the address.